### PR TITLE
refactor: consolidate OrderedIdDict into a single kv dict

### DIFF
--- a/src/OrderedIdDict.jl
+++ b/src/OrderedIdDict.jl
@@ -1,13 +1,13 @@
 using OrderedCollections: OrderedCollections
 
 struct OrderedIdDict{K,V} <: AbstractDict{K,V}
-    keys::OrderedCollections.OrderedDict{UInt,K}
-    values::OrderedCollections.OrderedDict{UInt,V}
+    kv::OrderedCollections.OrderedDict{UInt,Pair{K,V}}
 
     function OrderedIdDict{K,V}(pairs) where {K,V}
         return new(
-            OrderedCollections.OrderedDict{UInt,K}(objectid(k) => k for (k, _) in pairs),
-            OrderedCollections.OrderedDict{UInt,V}(objectid(k) => v for (k, v) in pairs),
+            OrderedCollections.OrderedDict{UInt,Pair{K,V}}(
+                objectid(k) => (k => v) for (k, v) in pairs
+            ),
         )
     end
 end
@@ -15,45 +15,41 @@ end
 OrderedIdDict() = OrderedIdDict{Any,Any}()
 OrderedIdDict{K,V}() where {K,V} = OrderedIdDict{K,V}(Pair{K,V}[])
 
-Base.show(io::IO, d::OrderedIdDict) = show(io, d.keys)
+Base.show(io::IO, d::OrderedIdDict) = show(io, d.kv)
 
 OrderedCollections.isordered(::OrderedIdDict) = true
 
-Base.length(d::OrderedIdDict) = length(d.keys)
-Base.isempty(d::OrderedIdDict) = isempty(d.keys)
+Base.length(d::OrderedIdDict) = length(d.kv)
+Base.isempty(d::OrderedIdDict) = isempty(d.kv)
 
 function Base.getindex(d::OrderedIdDict, k)
-    return d.values[objectid(k)]
+    return d.kv[objectid(k)].second
 end
 
 function Base.setindex!(d::OrderedIdDict, v, k)
-    d.keys[objectid(k)] = k
-    d.values[objectid(k)] = v
+    d.kv[objectid(k)] = k => v
     return d
 end
 
 function Base.haskey(d::OrderedIdDict, k)
-    return haskey(d.keys, objectid(k))
+    return haskey(d.kv, objectid(k))
 end
 
 function Base.delete!(d::OrderedIdDict, k)
-    delete!(d.keys, objectid(k))
-    delete!(d.values, objectid(k))
+    delete!(d.kv, objectid(k))
     return d
 end
 
 function Base.iterate(d::OrderedIdDict)
-    k = iterate(d.keys)
-    isnothing(k) && return nothing
-    ((_, k), _) = k
-    (_, v), state = iterate(d.values)
-    return k => v, state
+    r = iterate(d.kv)
+    isnothing(r) && return nothing
+    (_, kv), state = r
+    return kv, state
 end
 
 function Base.iterate(d::OrderedIdDict, state)
-    k = iterate(d.keys, state)
-    isnothing(k) && return nothing
-    ((_, k), _) = k
-    (_, v), state = iterate(d.values, state)
-    return k => v, state
+    r = iterate(d.kv, state)
+    isnothing(r) && return nothing
+    (_, kv), state = r
+    return kv, state
 end


### PR DESCRIPTION
## Summary

- Replace two parallel `OrderedDict`s (`keys` + `values`) with a single `OrderedDict{UInt,Pair{K,V}}`
- Halves the number of hash table operations on `setindex!` and `delete!`
- Fixes a latent iteration bug where key and value iterators could desync if their internal states diverged

## Test plan

- [ ] Existing tests pass
- [ ] Run `julia --project benchmark_ordered_id_dict.jl` to verify iteration performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)